### PR TITLE
Hashing Changes

### DIFF
--- a/C0mptCrypt/main.py
+++ b/C0mptCrypt/main.py
@@ -7,15 +7,16 @@ from Crypto.Util.Padding import pad, unpad
 # main.py
 # Date: 01/02/2022
 # Author: execution
+# Contributor: therealOri
 
 
 class C0mptCrypt:
 
     def __init__(self):
-        self.hash_key = hashlib.md5("c0mpt0".encode('utf-8')).digest()
+        self.hash_key = hashlib.blake2b("c0mpt0_&_Ori".encode('utf-8'), digest_size=16).digest()
 
     def Clear(self):
-        os.system('cls' if os.name == 'nt' else 'clear')
+        os.system('clear||cls')
 
     def EncryptSpinner(self):
         l = ['|', '/', '√', '\\']


### PR DESCRIPTION
Changed:
- Md5 hashing for self.hash_key is now using blake2b hashing instead. (Better and newer than Md5)
- Clear() function will now work on both linux and windows systems and no longer needs the if checks.

(All changes have been tested on my own fork and seem to work just fine. digest_size must be 16 or less or else it won't work as that's what the AES encryption requires.)